### PR TITLE
Fix Docker user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,14 +42,10 @@ ENV \
   " \
   CATALINA_OPTS="-server -Xmx512m"
 
-# Create wrenig user
 ARG WRENIG_UID=1000
-ARG WRENIG_GID=1000
-RUN addgroup --gid ${WRENIG_GID} wrenig && \
-    adduser --uid ${WRENIG_UID} --gid ${WRENIG_GID} --system wrenig
 
 # Deploy wrenig project
-COPY --chown=wrenig:root --from=project-build /build/wrenig /usr/local/tomcat/webapps/ROOT
+COPY --from=project-build /build/wrenig /usr/local/tomcat/webapps/ROOT
 
 USER ${WRENIG_UID}
 WORKDIR ${WRENIG_HOME}


### PR DESCRIPTION
This PR fixes a bug when creating docker user with UID 1000. Official Ubuntu 23.04+ images already contain predefined ubuntu user with this UID.

See https://bugs.launchpad.net/cloud-images/+bug/2005129/comments/1 describing the reasons for this change.