### PR TITLE
Check OIDC ID token nonce

### DIFF
--- a/openig-oauth2/src/main/java/org/forgerock/openig/filter/oauth2/client/AuthorizationRedirectHandler.java
+++ b/openig-oauth2/src/main/java/org/forgerock/openig/filter/oauth2/client/AuthorizationRedirectHandler.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2025 Wren Security.
  */
 package org.forgerock.openig.filter.oauth2.client;
 
@@ -136,6 +137,16 @@ class AuthorizationRedirectHandler implements Handler {
             final String nonce = createAuthorizationNonce();
             final String hash = createAuthorizationNonceHash(nonce);
             query.add("state", createAuthorizationState(hash, gotoUri));
+
+            /**
+             * Nonce is optional in the authorization code flow according to the RFC (required
+             * only in the implicit flow), but some IdPs require it in this flow type as well.
+             * So we will send the value in all authorization requests. The value is checked
+             * during the ID token validation.
+             */
+            if (requestedScopes.contains("openid")) {
+                query.add("nonce", nonce);
+            }
 
             final String redirect = appendQuery(issuer.getAuthorizeEndpoint(), query).toString();
 

--- a/openig-oauth2/src/main/java/org/forgerock/openig/filter/oauth2/client/OAuth2Session.java
+++ b/openig-oauth2/src/main/java/org/forgerock/openig/filter/oauth2/client/OAuth2Session.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2025 Wren Security.
  */
 package org.forgerock.openig.filter.oauth2.client;
 
@@ -212,6 +213,11 @@ final class OAuth2Session {
         }
         // Decode the ID token for OpenID Connect interactions.
         final SignedJwt idToken = extractIdToken(accessTokenResponse);
+        // Verify ID token nonce
+        if (idToken != null && authorizationRequestNonce != null && (!idToken.getClaimsSet().isDefined("nonce") ||
+                !authorizationRequestNonce.equals(idToken.getClaimsSet().getClaim("nonce")))) {
+            throw new OAuth2ErrorException(OAuth2Error.E_SERVER_ERROR, "ID token nonce does not match the value sent in the authentication request");
+        }
 
         return new OAuth2Session(time, clientRegistrationName, clientEndpoint, null, actualScopes,
                 accessTokenResponse, idToken, expiresAt);

--- a/openig-oauth2/src/test/java/org/forgerock/openig/filter/oauth2/client/OAuth2ClientFilterTest.java
+++ b/openig-oauth2/src/test/java/org/forgerock/openig/filter/oauth2/client/OAuth2ClientFilterTest.java
@@ -12,7 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2025 Wren Security.
  */
 package org.forgerock.openig.filter.oauth2.client;
 
@@ -361,7 +361,7 @@ public class OAuth2ClientFilterTest {
     @Test
     public void shouldFailToHandleAuthorizationCallbackWhenSessionStateIsNotAuthorizing() throws Exception {
         // Given
-        setUpForHandleAuthorizationCallbackCases("/callback?state=af0ifjsldkj");
+        setUpForHandleAuthorizationCallbackCases("/callback?state=n-0S6_WzA2Mj");
         final OAuth2ClientFilter filter = buildOAuth2ClientFilter().setRequireHttps(false);
         setSessionAuthorized();
 
@@ -378,7 +378,7 @@ public class OAuth2ClientFilterTest {
     @Test
     public void shouldFailToHandleAuthorizationCallbackWhenNoCodeProvided() throws Exception {
         // Given
-        setUpForHandleAuthorizationCallbackCases("/callback?state=af0ifjsldkj");
+        setUpForHandleAuthorizationCallbackCases("/callback?state=n-0S6_WzA2Mj");
         final OAuth2ClientFilter filter = buildOAuth2ClientFilter().setRequireHttps(false);
         setSessionAuthorized();
 
@@ -395,7 +395,7 @@ public class OAuth2ClientFilterTest {
     @Test
     public void shouldFailToHandleAuthorizationCallbackWhenNoClientRegistrationSpecified() throws Exception {
         // Given
-        setUpForHandleAuthorizationCallbackCases("/callback?state=af0ifjsldkj&code=authorizationCode");
+        setUpForHandleAuthorizationCallbackCases("/callback?state=n-0S6_WzA2Mj&code=authorizationCode");
         final OAuth2ClientFilter filter = buildOAuth2ClientFilter().setRequireHttps(false);
         setSessionAuthorized();
 
@@ -418,7 +418,7 @@ public class OAuth2ClientFilterTest {
                                                         field("refresh_token", NEW_REFRESH_TOKEN),
                                                         field("expires_in", 1000),
                                                         field("id_token", OAuth2TestUtils.ID_TOKEN))))));
-        setUpForHandleAuthorizationCallbackCases("/callback?state=af0ifjsldkj:redirectUri&code=authorizationCode");
+        setUpForHandleAuthorizationCallbackCases("/callback?state=n-0S6_WzA2Mj:redirectUri&code=authorizationCode");
         registrations.add(buildClientRegistration(DEFAULT_CLIENT_REGISTRATION_NAME, registrationHandler));
         final OAuth2ClientFilter filter = buildOAuth2ClientFilter().setRequireHttps(false);
         setSessionAuthorized();

--- a/openig-oauth2/src/test/java/org/forgerock/openig/filter/oauth2/client/OAuth2SessionTest.java
+++ b/openig-oauth2/src/test/java/org/forgerock/openig/filter/oauth2/client/OAuth2SessionTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions Copyright 2025 Wren Security.
  */
 package org.forgerock.openig.filter.oauth2.client;
 
@@ -127,7 +128,7 @@ public class OAuth2SessionTest {
         OAuth2Session session = OAuth2Session.stateNew(time)
                                              .stateAuthorizing("clientRegistration",
                                                                "endpoint",
-                                                               "nonce",
+                                                               "n-0S6_WzA2Mj",
                                                                asList("scope1", "scope2"))
                                              .stateAuthorized(accessTokenResponse);
         // @formatter:on
@@ -207,7 +208,7 @@ public class OAuth2SessionTest {
         OAuth2Session session = OAuth2Session.stateNew(time)
                                              .stateAuthorizing("clientRegistration",
                                                                "endpoint",
-                                                               "nonce",
+                                                               "n-0S6_WzA2Mj",
                                                                asList("scope1", "scope2"))
                                              .stateAuthorized(accessTokenResponse);
         // @formatter:on
@@ -264,7 +265,7 @@ public class OAuth2SessionTest {
         OAuth2Session session = OAuth2Session.stateNew(time)
                                              .stateAuthorizing("clientRegistration",
                                                                "endpoint",
-                                                               "nonce",
+                                                               "n-0S6_WzA2Mj",
                                                                asList("scope1", "scope2"))
                                              .stateAuthorized(accessTokenResponse)
                                              .stateRefreshed(refreshAccessTokenResponse);

--- a/openig-oauth2/src/test/java/org/forgerock/openig/filter/oauth2/client/OAuth2TestUtils.java
+++ b/openig-oauth2/src/test/java/org/forgerock/openig/filter/oauth2/client/OAuth2TestUtils.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2025 Wren Security.
  */
 package org.forgerock.openig.filter.oauth2.client;
 
@@ -111,7 +112,7 @@ public final class OAuth2TestUtils {
                                                   final String requestedUri,
                                                   final List<String> scopes) {
         return json(object(field("crn", clientRegistrationName),
-                           field("arn", "af0ifjsldkj"),
+                           field("arn", "n-0S6_WzA2Mj"),
                            field("ce", requestedUri),
                            field("s", scopes),
                            field("atr", object(field("access_token", ID_TOKEN),


### PR DESCRIPTION
This PR adds the sending of the `nonce` parameter in the _OpenID Connect_ authentication request (see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) to mitigate replay attacks.

Nonce is optional in the authorization code flow according to the RFC (required only in the implicit flow), but some IdPs (e.g. Bank iD, see https://developer.bankid.cz/docs/api/bankid-for-sep) require it in this flow type as well. So the value will be sent in all authorization requests. It is possible that some IdPs do not support the attribute at all, but I expect that in such a case the attribute will be ignored and the authorization request will be processed successfully.

The value is then checked during ID token validation (see https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation).