### PR TITLE
Replace restito with wiremock

### DIFF
--- a/openig-core/pom.xml
+++ b/openig-core/pom.xml
@@ -36,7 +36,7 @@
         <h2.version>2.2.224</h2.version>
         <juel.version>2.2.7</juel.version>
         <logback.version>1.2.13</logback.version>
-        <restito.version>1.1.0</restito.version>
+        <wiremock.version>3.11.0</wiremock.version>
         <simple-jndi.version>0.23.0</simple-jndi.version>
 
         <wrends.version>5.0.1</wrends.version>
@@ -155,9 +155,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.xebialabs.restito</groupId>
-            <artifactId>restito</artifactId>
-            <version>${restito.version}</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/openig-core/src/test/java/org/forgerock/openig/thread/MdcScheduledExecutorServiceDelegateTest.java
+++ b/openig-core/src/test/java/org/forgerock/openig/thread/MdcScheduledExecutorServiceDelegateTest.java
@@ -12,15 +12,12 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2025 Wren Security.
  */
 
 package org.forgerock.openig.thread;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -28,6 +25,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Collection;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +60,7 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
     @Captor
     private ArgumentCaptor<Collection<Callable<String>>> callablesCapture;
 
+    @Override
     @BeforeMethod
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
@@ -72,11 +71,13 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
         return new MdcScheduledExecutorServiceDelegate(delegate());
     }
 
+    @Override
     protected ScheduledExecutorService delegate() {
         return delegate;
     }
 
 
+    @Override
     @Test(expectedExceptions = NullPointerException.class)
     public void shouldFailBecauseNoDelegateIsProvided() throws Exception {
         new MdcScheduledExecutorServiceDelegate(null);
@@ -87,7 +88,7 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
         doReturn(scheduledFuture).when(delegate())
                                  .schedule(any(Runnable.class), eq(1L), eq(TimeUnit.SECONDS));
 
-        assertThat(executorService().schedule(runnable, 1, TimeUnit.SECONDS), is(equalTo(scheduledFuture)));
+        assertThat((Future<?>) executorService().schedule(runnable, 1, TimeUnit.SECONDS)).isEqualTo(scheduledFuture);
 
         verify(delegate()).schedule(runnableCapture.capture(), eq(1L), eq(TimeUnit.SECONDS));
         assertThatCapturedRunnableIsMdcAware();
@@ -99,7 +100,7 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
         doReturn(scheduledFuture).when(delegate())
                                  .schedule(any(Callable.class), eq(1L), eq(TimeUnit.SECONDS));
 
-        assertThat(executorService().schedule(callable, 1, TimeUnit.SECONDS), is(equalTo(scheduledFuture)));
+        assertThat((Future<?>) executorService().schedule(callable, 1, TimeUnit.SECONDS)).isEqualTo(scheduledFuture);
 
         verify(delegate()).schedule(callableCapture.capture(), eq(1L), eq(TimeUnit.SECONDS));
         assertThatCaptureCallableIsMdcAware();
@@ -110,7 +111,7 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
         doReturn(scheduledFuture).when(delegate())
                                  .scheduleAtFixedRate(any(Runnable.class), eq(1L), eq(2L), eq(TimeUnit.SECONDS));
 
-        assertThat(executorService().scheduleAtFixedRate(runnable, 1, 2, TimeUnit.SECONDS), is(equalTo(scheduledFuture)));
+        assertThat((Future<?>) executorService().scheduleAtFixedRate(runnable, 1, 2, TimeUnit.SECONDS)).isEqualTo(scheduledFuture);
 
         verify(delegate()).scheduleAtFixedRate(runnableCapture.capture(), eq(1L), eq(2L), eq(TimeUnit.SECONDS));
         assertThatCapturedRunnableIsMdcAware();
@@ -121,17 +122,17 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
         doReturn(scheduledFuture).when(delegate())
                                  .scheduleWithFixedDelay(any(Runnable.class), eq(1L), eq(2L), eq(TimeUnit.SECONDS));
 
-        assertThat(executorService().scheduleWithFixedDelay(runnable, 1, 2, TimeUnit.SECONDS), is(equalTo(scheduledFuture)));
+        assertThat((Future<?>) executorService().scheduleWithFixedDelay(runnable, 1, 2, TimeUnit.SECONDS)).isEqualTo(scheduledFuture);
 
         verify(delegate()).scheduleWithFixedDelay(runnableCapture.capture(), eq(1L), eq(2L), eq(TimeUnit.SECONDS));
         assertThatCapturedRunnableIsMdcAware();
     }
 
     private void assertThatCapturedRunnableIsMdcAware() {
-        assertThat(runnableCapture.getValue(), is(instanceOf(MdcScheduledExecutorServiceDelegate.MdcRunnable.class)));
+        assertThat(runnableCapture.getValue()).isInstanceOf(MdcScheduledExecutorServiceDelegate.MdcRunnable.class);
     }
 
     private void assertThatCaptureCallableIsMdcAware() {
-        assertThat(callableCapture.getValue(), is(instanceOf(MdcScheduledExecutorServiceDelegate.MdcCallable.class)));
+        assertThat(callableCapture.getValue()).isInstanceOf(MdcScheduledExecutorServiceDelegate.MdcCallable.class);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     </issueManagement>
 
     <properties>
-        <pgpVerifyKeysVersion>1.7.13</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.8.2</pgpVerifyKeysVersion>
         <wrensec.commons.version>22.6.0</wrensec.commons.version>
 
         <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>


### PR DESCRIPTION
This PR replaces `Restito` with the more commonly used `WireMock`.