### PR TITLE
Upgrade Groovy to 3.0.25

### DIFF
--- a/openig-core/pom.xml
+++ b/openig-core/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <dropwizard-metrics.version>3.1.2</dropwizard-metrics.version>
-        <groovy.version>2.4.21</groovy.version>
+        <groovy.version>3.0.25</groovy.version>
         <h2.version>2.2.224</h2.version>
         <juel.version>2.2.7</juel.version>
         <logback.version>1.2.13</logback.version>
@@ -78,6 +78,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>
+            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
     </issueManagement>
 
     <properties>
+        <pgpVerifyKeysVersion>1.8.4</pgpVerifyKeysVersion>
         <wrensec.commons.version>22.6.1</wrensec.commons.version>
 
         <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>


### PR DESCRIPTION
This PR upgrades Groovy to the latest release with unchanged  coordinates. The Groovy 3.x version is still being maintained because the latest release was performed one week ago.