### PR TITLE
Upgrade Wren:AM to 15.2.0-M1

### DIFF
--- a/openig-saml/pom.xml
+++ b/openig-saml/pom.xml
@@ -30,7 +30,7 @@
     <name>Wren:IG - SAML</name>
 
     <properties>
-        <wrenam.version>15.1.3</wrenam.version>
+        <wrenam.version>15.2.0-M1</wrenam.version>
         <saaj-impl.version>1.5.3</saaj-impl.version>
     </properties>
 


### PR DESCRIPTION
This PR upgrades `wrenam` to release 15.2.0-M1.