### PR TITLE
Ignore push event on dependabot branches

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -2,6 +2,8 @@ name: Build project
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
 
 permissions:


### PR DESCRIPTION
Dependabot creates a branch and a PR. Actions will be triggered for both without this change.